### PR TITLE
Fix typo in Dutch docs (Nl.elm)

### DIFF
--- a/src/PluralRules/Nl.elm
+++ b/src/PluralRules/Nl.elm
@@ -36,7 +36,7 @@ defaultPluralize word =
     word ++ "en"
 
 
-{-| Pluralization function for French rules (adding `"en"` in the general case).
+{-| Pluralization function for Dutch rules (adding `"en"` in the general case).
 
 Make your own helper function that gives `pluralize` your rules, so that you
 don't need to mention them every time!


### PR DESCRIPTION
The dutch docs had a residual copy and past text referring to the french rules (which makes no sense) 😉 